### PR TITLE
Add "anicent" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ alloc = []
 std = ["alloc"]
 nightly = []
 std-nightly = ["std", "nightly"]
+ancient = []
 
 [package.metadata.docs.rs]
 features = ["nightly"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -77,7 +77,7 @@ struct Custom {
 /// [`io::Error`]: Error
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 // #[allow(deprecated)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "ancient"), non_exhaustive)]
 pub enum ErrorKind {
     /// An entity was not found, often a file.
     NotFound,


### PR DESCRIPTION
This allows the project to compile for 1.36.0, the version stabilized `alloc`.

This would close #2.

Not sure if this is the best feature name ...