### PR TITLE
Add impls for standard errors from core library

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -324,6 +324,25 @@ impl Error for ! {}
 
 impl Error for LayoutErr {}
 
+impl Error for core::str::ParseBoolError {}
+
+impl Error for core::str::Utf8Error {}
+
+impl Error for core::num::ParseIntError {}
+
+impl Error for core::num::TryFromIntError {}
+
+impl Error for core::array::TryFromSliceError {}
+
+impl Error for core::num::ParseFloatError {}
+
+#[cfg(feature = "alloc")]
+impl Error for alloc::string::FromUtf8Error {}
+
+#[cfg(feature = "alloc")]
+impl Error for alloc::string::FromUtf16Error {}
+
+
 #[cfg(feature = "alloc")]
 impl<T: Error> Error for Box<T> {
     fn source(&self) -> Option<&(dyn Error + 'static)> {


### PR DESCRIPTION
Hey,
this PR adds remaining implementations for errors existing in Rust 1.47's `core`/`alloc` module that were previously omitted.