### PR TITLE
Use stable features where possible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: [1.47]
+        rust: [1.55]
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,17 +49,17 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features
+          args: --tests --no-default-features
       - name: Run tests (std)
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features std
+          args: --tests --no-default-features --features std
       - name: Run tests (alloc)
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features alloc
+          args: --tests --no-default-features --features alloc
   test-msrv:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -78,14 +78,14 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features
+          args: --tests --no-default-features
       - name: Run tests (std)
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features std
+          args: --tests --no-default-features --features std
       - name: Run tests (alloc)
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features alloc
+          args: --tests --no-default-features --features alloc

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Actions Status](https://github.com/bbqsrc/core2/workflows/CI/badge.svg)](https://github.com/bbqsrc/core2/actions)
 [![Documentation](https://docs.rs/core2/badge.svg)](https://docs.rs/core2)
-![Minimum Supported Rust Version (MSRV)](https://img.shields.io/badge/rust-v1.47.0+-blue)
+![Minimum Supported Rust Version (MSRV)](https://img.shields.io/badge/rust-v1.55.0+-blue)
 
 Ever wanted a `Cursor` or the `Error` trait in `no_std`? Well now you can have it. A 'fork' of Rust's `std` modules for `no_std` environments, with the added benefit of optionally taking advantage of `alloc`.
 
@@ -29,20 +29,19 @@ use `core2::error::Error` in place of `std::error::Error`.
 
 - **std**: enables `std` pass-throughs for the polyfilled types, but allows accessing the new types
 - **alloc**: enable aspects of the `Read` and `Write` traits that require `alloc` support (WIP)
-- **nightly**: enables **nightly**-only features, such as `BufReader` and `BufWriter` with const generic buffers.
+- **nightly**: enables **nightly**-only features
 
 ### Differences to `std::io`
 
 - No `std::io::Error`, so we have our own copy without any `Os` error functions
 - `IoSlice` and the `*_vectored` family of functions are not implemented.
-- `BufReader` and `BufWriter` have a different signature, as they now use a const generic bounded array for the internal buffer. (Requires **nightly** feature)
+- `BufReader` and `BufWriter` have a different signature, as they now use a const generic bounded array for the internal buffer.
 
 Other than items perhaps being entirely missing or certain functions unavailable on some traits, no function signatures have been changed.
 
 ### Limitations
 
-- Using the buffer types currently requires **nightly** due to the use of const generics.
-- Using `copy` or the buffer types with `std` support currently requires **nightly** due to the `initializer` API.
+- The `Error` implementation for the never type currently requires **nightly**.
 
 ## Where is it used?
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "nightly")]
 mod buffered;
 mod cursor;
 mod error;
@@ -19,8 +18,6 @@ pub use std::io::{
 };
 
 // Use this crate's implementation on both std and no_std
-#[cfg(feature = "nightly")]
 pub use buffered::{BufReader, BufWriter, LineWriter};
 
-#[cfg(feature = "nightly")]
 pub use util::copy;

--- a/src/io/util.rs
+++ b/src/io/util.rs
@@ -1,10 +1,7 @@
-#[cfg(feature = "nightly")]
 use core::mem::MaybeUninit;
 
-#[cfg(feature = "nightly")]
 use crate::io::{ErrorKind, Read, Write};
 
-#[cfg(feature = "nightly")]
 pub fn copy<R: ?Sized, W: ?Sized, const S: usize>(
     reader: &mut R,
     writer: &mut W,
@@ -14,17 +11,6 @@ where
     W: Write,
 {
     let mut buf = MaybeUninit::<[u8; S]>::uninit();
-    // FIXME: #42788
-    //
-    //   - This creates a (mut) reference to a slice of
-    //     _uninitialized_ integers, which is **undefined behavior**
-    //
-    //   - Only the standard library gets to soundly "ignore" this,
-    //     based on its privileged knowledge of unstable rustc
-    //     internals;
-    unsafe {
-        reader.initializer().initialize(buf.assume_init_mut());
-    }
 
     let mut written = 0;
     loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
-#![cfg_attr(feature = "nightly", feature(maybe_uninit_ref))]
 #![cfg_attr(feature = "nightly", feature(never_type))]
-#![cfg_attr(all(feature = "std", feature = "nightly"), feature(read_initializer))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "std", allow(dead_code))]
 


### PR DESCRIPTION
`io::copy()` as well as the `BufReader`/`BufWriter` don't need nightly
Rust anymore as they the features needed are available on more recent
stable Rust versions. This commit bumps the MSRV to 1.55.

Closes #15.