### PR TITLE
[WIP: do not merge] fixup/ci: feature-gate stabilized compiler features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["no-std"]
 
 [dependencies]
 memchr = { version = "2", default-features = false }
+rustversion = "1.0"
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
-#![cfg_attr(feature = "nightly", feature(maybe_uninit_ref))]
 #![cfg_attr(feature = "nightly", feature(never_type))]
-#![cfg_attr(all(feature = "std", feature = "nightly"), feature(read_initializer))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "std", allow(dead_code))]
+#[rustversion::attr(all(before(1.55), nightly), feature(maybe_uninit_ref))]
+#[rustversion::attr(all(before(1.55), nightly), feature(read_initializer))]
 
 #[cfg(not(feature = "std"))]
 pub mod error;


### PR DESCRIPTION
Adds conditional feature-gates based on `rustc` version to only include unstable features on older compiler versions.

Introduces the `rustversion` dependency to handle the feature-gates.

Fixes breaking CI builds.