### PR TITLE
Update Cargo.toml repository link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Brendan Molloy <brendan@bbqsrc.net>"]
 description = "The bare essentials of std::io for use in no_std. Alloc support is optional."
 license = "Apache-2.0 OR MIT"
 edition = "2018"
-repository = "https://github.com/bbqsrc/core2"
+repository = "https://github.com/technocreatives/core2"
 categories = ["no-std"]
 
 [dependencies]


### PR DESCRIPTION
it seems this project is mainly maintained in this org not the fork, right? this appears to be legacy metadata from a repository transfer (if any).